### PR TITLE
Update jax dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/google/lineax" }
-dependencies = ["jax>=0.4.13", "jaxtyping>=0.2.20", "equinox>=0.11.3", "typing_extensions>=4.5.0"]
+dependencies = ["jax>=0.4.26", "jaxtyping>=0.2.20", "equinox>=0.11.3", "typing_extensions>=4.5.0"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
With the new [release]( https://github.com/google/jax/releases/tag/jaxlib-v0.4.26) we can finally forget about the nasty XLA bug