### PR TITLE
Diagonal solver now works with differently input+output structures

### DIFF
--- a/lineax/_misc.py
+++ b/lineax/_misc.py
@@ -31,7 +31,11 @@ def tree_where(
 
 def resolve_rcond(rcond, n, m, dtype):
     if rcond is None:
-        return jnp.finfo(dtype).eps * max(n, m)
+        # This `2 *` is a heuristic: I have seen very rare failures without it, in ways
+        # that seem to depend on JAX compilation state. (E.g. running unrelated JAX
+        # computations beforehand, in a completely different JIT-compiled region, can
+        # result in differences in the success/failure of the solve.)
+        return 2 * jnp.finfo(dtype).eps * max(n, m)
     else:
         return jnp.where(rcond < 0, jnp.finfo(dtype).eps, rcond)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lineax"
-version = "0.0.6"
+version = "0.0.7"
 description = "Linear solvers in JAX and Equinox."
 readme = "README.md"
 requires-python ="~=3.9"


### PR DESCRIPTION
Honestly, it's a little suspicious whether we should even allow this: should being diagonal perhaps imply that the input and output structures are identical?

Right now I'm choosing to allow this because it's pretty subtle, and users can apply their own diagonal tags, so if nothign else it's an easy mistake to be tolerant of.

In particular, *we* were making this mistake by treating scalar operators as diagonal even when they had different structures. This was causing a downstream issue in Diffrax.