### PR TITLE
Add a diagonal pytree linear operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ examples/data
 .all_objects.cache
 .pymon
 .idea
+.venv

--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -28,6 +28,13 @@ Or, perhaps we only have a function $F : \mathbb{R}^m \to \mathbb{R}^n$ such tha
 
 ---
 
+::: lineax.DiagonalLinearOperator
+    selection: 
+        members: 
+            - __init__
+
+---
+
 ::: lineax.TridiagonalLinearOperator
     selection:
         members:
@@ -38,13 +45,6 @@ Or, perhaps we only have a function $F : \mathbb{R}^m \to \mathbb{R}^n$ such tha
 ::: lineax.PyTreeLinearOperator
     selection:
         members:
-            - __init__
-
----
-
-::: lineax.DiagonalLinearOperator
-    selection: 
-        members: 
             - __init__
 
 ---

--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -49,6 +49,13 @@ Or, perhaps we only have a function $F : \mathbb{R}^m \to \mathbb{R}^n$ such tha
 
 ---
 
+::: lineax.PyTreeDiagonalLinearOperator
+    selection: 
+        members: 
+            - __init__
+
+---
+
 ::: lineax.JacobianLinearOperator
     selection:
         members:

--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -28,13 +28,6 @@ Or, perhaps we only have a function $F : \mathbb{R}^m \to \mathbb{R}^n$ such tha
 
 ---
 
-::: lineax.DiagonalLinearOperator
-    selection:
-        members:
-            - __init__
-
----
-
 ::: lineax.TridiagonalLinearOperator
     selection:
         members:
@@ -49,7 +42,7 @@ Or, perhaps we only have a function $F : \mathbb{R}^m \to \mathbb{R}^n$ such tha
 
 ---
 
-::: lineax.PyTreeDiagonalLinearOperator
+::: lineax.DiagonalLinearOperator
     selection: 
         members: 
             - __init__

--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -40,6 +40,7 @@ from ._operator import (
     MatrixLinearOperator as MatrixLinearOperator,
     MulLinearOperator as MulLinearOperator,
     NegLinearOperator as NegLinearOperator,
+    PyTreeDiagonalLinearOperator as PyTreeDiagonalLinearOperator,
     PyTreeLinearOperator as PyTreeLinearOperator,
     TaggedLinearOperator as TaggedLinearOperator,
     TangentLinearOperator as TangentLinearOperator,

--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -40,7 +40,6 @@ from ._operator import (
     MatrixLinearOperator as MatrixLinearOperator,
     MulLinearOperator as MulLinearOperator,
     NegLinearOperator as NegLinearOperator,
-    PyTreeDiagonalLinearOperator as PyTreeDiagonalLinearOperator,
     PyTreeLinearOperator as PyTreeLinearOperator,
     TaggedLinearOperator as TaggedLinearOperator,
     TangentLinearOperator as TangentLinearOperator,

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -1576,6 +1576,7 @@ def _(operator):
 
 @is_diagonal.register(IdentityLinearOperator)
 @is_diagonal.register(DiagonalLinearOperator)
+@is_diagonal.register(PyTreeDiagonalLinearOperator)
 def _(operator):
     return True
 

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -1658,6 +1658,7 @@ def _(operator):
 
 @has_unit_diagonal.register(DiagonalLinearOperator)
 @has_unit_diagonal.register(TridiagonalLinearOperator)
+@has_unit_diagonal.register(PyTreeDiagonalLinearOperator)
 def _(operator):
     # TODO: refine this
     return False
@@ -1694,6 +1695,7 @@ def _(operator):
 
 @is_lower_triangular.register(IdentityLinearOperator)
 @is_lower_triangular.register(DiagonalLinearOperator)
+@is_lower_triangular.register(PyTreeDiagonalLinearOperator)
 def _(operator):
     return True
 
@@ -1734,6 +1736,7 @@ def _(operator):
 
 @is_upper_triangular.register(IdentityLinearOperator)
 @is_upper_triangular.register(DiagonalLinearOperator)
+@is_upper_triangular.register(PyTreeDiagonalLinearOperator)
 def _(operator):
     return True
 

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -480,7 +480,7 @@ class DiagonalLinearOperator(AbstractLinearOperator, strict=True):
     pointwise diagonal * vector, rather than a full matrix @ vector (for speed).
 
     The diagonal may also be a PyTree, rather than a 1D array. When materialising the
-    matrix, the diagonal is taken to be defined by the flattened PyTree (i.e. values 
+    matrix, the diagonal is taken to be defined by the flattened PyTree (i.e. values
     show up in the same order.)
     """
 
@@ -1435,7 +1435,7 @@ def _(operator):
 
 @tridiagonal.register(DiagonalLinearOperator)
 def _(operator):
-    diag = diagonal(operator) 
+    diag = diagonal(operator)
     upper_diag = jnp.zeros(diag.size - 1)
     lower_diag = jnp.zeros(diag.size - 1)
     return diag, lower_diag, upper_diag

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -476,10 +476,8 @@ class PyTreeLinearOperator(AbstractLinearOperator, strict=True):
 
 class DiagonalLinearOperator(AbstractLinearOperator, strict=True):
     """A diagonal linear operator, with a single PyTree defining the diagonal. It 
-    returns a PyTree of the same shape as the input PyTree. If the diagonal is a 1D 
-    array, then the operator is equivalent to a matrix with that array on the diagonal.
-    When materialising the matrix, a 2D array is returned, where the diagonal is defined
-    by the flattened input PyTree.
+    returns a PyTree of the same shape as the input PyTree. Only the PyTree is stored 
+    for efficiency, and only element-wise operations are performed.
     """
 
     pytree: PyTree[Inexact[Array, "..."]]

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -811,42 +811,6 @@ class IdentityLinearOperator(AbstractLinearOperator, strict=True):
         return frozenset()
 
 
-# class DiagonalLinearOperator(AbstractLinearOperator, strict=True):
-#     """As [`lineax.MatrixLinearOperator`][], but for specifically a diagonal matrix.
-
-#     Only the diagonal of the matrix is stored (for memory efficiency). Matrix-vector
-#     products are computed by doing a pointwise `diagonal * vector`, rather than a full
-#     `matrix @ vector` (for speed).
-#     """
-
-#     diagonal: Inexact[Array, " size"]
-
-#     def __init__(self, diagonal: Shaped[Array, " size"]):
-#         """**Arguments:**
-
-#         - `diagonal`: A rank-one JAX array, i.e. of shape `(a,)` for some `a`. This is
-#             the diagonal of the matrix.
-#         """
-#         self.diagonal = inexact_asarray(diagonal)
-
-#     def mv(self, vector):
-#         return self.diagonal * vector
-
-#     def as_matrix(self):
-#         return jnp.diag(self.diagonal)
-
-#     def transpose(self):
-#         return self
-
-#     def in_structure(self):
-#         (size,) = jnp.shape(self.diagonal)
-#         return jax.ShapeDtypeStruct(shape=(size,), dtype=self.diagonal.dtype)
-
-#     def out_structure(self):
-#         (size,) = jnp.shape(self.diagonal)
-#         return jax.ShapeDtypeStruct(shape=(size,), dtype=self.diagonal.dtype)
-
-
 class TridiagonalLinearOperator(AbstractLinearOperator, strict=True):
     """As [`lineax.MatrixLinearOperator`][], but for specifically a tridiagonal
     matrix.

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -2112,7 +2112,7 @@ def _(operator):
 @conj.register(PyTreeDiagonalLinearOperator)
 def _(operator):
     pytree_conj = jtu.tree_map(lambda x: x.conj(), operator.pytree)
-    return PyTreeDiagonalLinearOperator(pytree_conj, operator.tags)
+    return PyTreeDiagonalLinearOperator(pytree_conj)
 
 
 @conj.register(JacobianLinearOperator)

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -2095,6 +2095,12 @@ def _(operator):
     return PyTreeLinearOperator(pytree_conj, operator.out_structure(), operator.tags)
 
 
+@conj.register(PyTreeDiagonalLinearOperator)
+def _(operator):
+    pytree_conj = jtu.tree_map(lambda x: x.conj(), operator.pytree)
+    return PyTreeDiagonalLinearOperator(pytree_conj, operator.tags)
+
+
 @conj.register(JacobianLinearOperator)
 def _(operator):
     return conj(linearise(operator))

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -478,6 +478,9 @@ class DiagonalLinearOperator(AbstractLinearOperator, strict=True):
     """A diagonal linear operator, with a single PyTree defining the diagonal. It 
     returns a PyTree of the same shape as the input PyTree. Only the PyTree is stored 
     for efficiency, and only element-wise operations are performed.
+
+    This operator generalises a diagonal linear operator (the PyTree may be a 1D array), 
+    similar to how [lineax.PyTreeLinearOperator][] generalises a matrix linear operator.
     """
 
     pytree: PyTree[Inexact[Array, "..."]]

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -488,8 +488,10 @@ class PyTreeDiagonalLinearOperator(AbstractLinearOperator, strict=True):
 
         - `pytree`: a PyTree.
         """
-        self.pytree = jtu.tree_map(inexact_asarray, pytree)
+        pytree = jtu.tree_map(inexact_asarray, pytree)
         structure = jax.eval_shape(lambda: pytree)
+        
+        self.pytree = pytree
         self.input_structure = jtu.tree_flatten(structure)
         self.output_structure = jtu.tree_flatten(structure)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -202,6 +202,13 @@ def make_diagonal_operator(getkey, matrix, tags):
 
 
 @_operators_append
+def make_trivial_pytree_diagonal_operator(getkey, matrix, tags):
+    assert tags == lx.diagonal_tag
+    diag = jnp.diag(matrix)  
+    return lx.PyTreeDiagonalLinearOperator(diag)
+
+
+@_operators_append
 def make_identity_operator(getkey, matrix, tags):
     in_struct = jax.ShapeDtypeStruct((matrix.shape[-1],), matrix.dtype)
     return lx.IdentityLinearOperator(input_structure=in_struct)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -132,7 +132,10 @@ def params(only_pseudo):
         for solver, tags, pseudoinverse in solvers_tags_pseudoinverse:
             if only_pseudo and not pseudoinverse:
                 continue
-            if make_operator is make_trivial_diagonal_operator and tags != lx.diagonal_tag:
+            if (
+                make_operator is make_trivial_diagonal_operator
+                and tags != lx.diagonal_tag
+            ):
                 continue
             if make_operator is make_identity_operator and tags != lx.unit_diagonal_tag:
                 continue

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -132,18 +132,13 @@ def params(only_pseudo):
         for solver, tags, pseudoinverse in solvers_tags_pseudoinverse:
             if only_pseudo and not pseudoinverse:
                 continue
-            if make_operator is make_diagonal_operator and tags != lx.diagonal_tag:
+            if make_operator is make_trivial_diagonal_operator and tags != lx.diagonal_tag:
                 continue
             if make_operator is make_identity_operator and tags != lx.unit_diagonal_tag:
                 continue
             if (
                 make_operator is make_tridiagonal_operator
                 and tags != lx.tridiagonal_tag
-            ):
-                continue
-            if (
-                make_operator is make_trivial_pytree_diagonal_operator
-                and tags != lx.diagonal_tag
             ):
                 continue
             yield make_operator, solver, tags
@@ -200,17 +195,10 @@ def make_jac_operator(getkey, matrix, tags):
 
 
 @_operators_append
-def make_diagonal_operator(getkey, matrix, tags):
+def make_trivial_diagonal_operator(getkey, matrix, tags):
     assert tags == lx.diagonal_tag
     diag = jnp.diag(matrix)
     return lx.DiagonalLinearOperator(diag)
-
-
-@_operators_append
-def make_trivial_pytree_diagonal_operator(getkey, matrix, tags):
-    assert tags == lx.diagonal_tag
-    diag = jnp.diag(matrix)
-    return lx.PyTreeDiagonalLinearOperator(diag)
 
 
 @_operators_append

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -141,6 +141,11 @@ def params(only_pseudo):
                 and tags != lx.tridiagonal_tag
             ):
                 continue
+            if (
+                make_operator is make_trivial_pytree_diagonal_operator
+                and tags != lx.diagonal_tag
+            ):
+                continue
             yield make_operator, solver, tags
 
 
@@ -204,7 +209,7 @@ def make_diagonal_operator(getkey, matrix, tags):
 @_operators_append
 def make_trivial_pytree_diagonal_operator(getkey, matrix, tags):
     assert tags == lx.diagonal_tag
-    diag = jnp.diag(matrix)  
+    diag = jnp.diag(matrix)
     return lx.PyTreeDiagonalLinearOperator(diag)
 
 

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -6,11 +6,10 @@ import pytest
 from lineax import FunctionLinearOperator
 
 from .helpers import (
-    make_diagonal_operator,
     make_identity_operator,
     make_operators,
     make_tridiagonal_operator,
-    make_trivial_pytree_diagonal_operator,
+    make_trivial_diagonal_operator,
     tree_allclose,
 )
 
@@ -19,9 +18,8 @@ from .helpers import (
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
 def test_adjoint(make_operator, dtype, getkey):
     if (
-        make_operator is make_diagonal_operator
+        make_operator is make_trivial_diagonal_operator
         or make_operator is make_identity_operator
-        or make_operator is make_trivial_pytree_diagonal_operator
     ):
         matrix = jnp.eye(4, dtype=dtype)
         tags = lx.diagonal_tag

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -10,6 +10,7 @@ from .helpers import (
     make_identity_operator,
     make_operators,
     make_tridiagonal_operator,
+    make_trivial_pytree_diagonal_operator,
     tree_allclose,
 )
 
@@ -20,6 +21,7 @@ def test_adjoint(make_operator, dtype, getkey):
     if (
         make_operator is make_diagonal_operator
         or make_operator is make_identity_operator
+        or make_operator is make_trivial_pytree_diagonal_operator
     ):
         matrix = jnp.eye(4, dtype=dtype)
         tags = lx.diagonal_tag

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -22,11 +22,10 @@ import lineax as lx
 import pytest
 
 from .helpers import (
-    make_diagonal_operator,
     make_identity_operator,
     make_operators,
     make_tridiagonal_operator,
-    make_trivial_pytree_diagonal_operator,
+    make_trivial_diagonal_operator,
     tree_allclose,
 )
 
@@ -35,9 +34,8 @@ from .helpers import (
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
 def test_ops(make_operator, getkey, dtype):
     if (
-        make_operator is make_diagonal_operator
+        make_operator is make_trivial_diagonal_operator
         or make_operator is make_identity_operator
-        or make_operator is make_trivial_pytree_diagonal_operator
     ):
         matrix = jnp.eye(3, dtype=dtype)
         tags = lx.diagonal_tag
@@ -84,9 +82,8 @@ def test_ops(make_operator, getkey, dtype):
 @pytest.mark.parametrize("make_operator", make_operators)
 def test_structures_vector(make_operator, getkey):
     if (
-        make_operator is make_diagonal_operator
+        make_operator is make_trivial_diagonal_operator
         or make_operator is make_identity_operator
-        or make_operator is make_trivial_pytree_diagonal_operator
     ):
         matrix = jnp.eye(4)
         tags = lx.diagonal_tag
@@ -109,7 +106,7 @@ def test_structures_vector(make_operator, getkey):
 
 def _setup(getkey, matrix, tag: Union[object, frozenset[object]] = frozenset()):
     for make_operator in make_operators:
-        if make_operator is make_diagonal_operator and tag != lx.diagonal_tag:
+        if make_operator is make_trivial_diagonal_operator and tag != lx.diagonal_tag:
             continue
         if make_operator is make_tridiagonal_operator and tag not in (
             lx.tridiagonal_tag,
@@ -122,8 +119,6 @@ def _setup(getkey, matrix, tag: Union[object, frozenset[object]] = frozenset()):
             lx.diagonal_tag,
             lx.symmetric_tag,
         ):
-            continue
-        if make_operator is make_trivial_pytree_diagonal_operator and tag != lx.diagonal_tag:
             continue
         operator = make_operator(getkey, matrix, tag)
         yield operator

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -26,6 +26,7 @@ from .helpers import (
     make_identity_operator,
     make_operators,
     make_tridiagonal_operator,
+    make_trivial_pytree_diagonal_operator,
     tree_allclose,
 )
 
@@ -36,6 +37,7 @@ def test_ops(make_operator, getkey, dtype):
     if (
         make_operator is make_diagonal_operator
         or make_operator is make_identity_operator
+        or make_operator is make_trivial_pytree_diagonal_operator
     ):
         matrix = jnp.eye(3, dtype=dtype)
         tags = lx.diagonal_tag
@@ -84,6 +86,7 @@ def test_structures_vector(make_operator, getkey):
     if (
         make_operator is make_diagonal_operator
         or make_operator is make_identity_operator
+        or make_operator is make_trivial_pytree_diagonal_operator
     ):
         matrix = jnp.eye(4)
         tags = lx.diagonal_tag
@@ -119,6 +122,8 @@ def _setup(getkey, matrix, tag: Union[object, frozenset[object]] = frozenset()):
             lx.diagonal_tag,
             lx.symmetric_tag,
         ):
+            continue
+        if make_operator is make_trivial_pytree_diagonal_operator and tag != lx.diagonal_tag:
             continue
         operator = make_operator(getkey, matrix, tag)
         yield operator

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -48,10 +48,10 @@ def test_nontrivial_pytree_operator():
     assert tree_allclose(out, true_out)
 
 
-def test_nontrivial_pytree_diagonal_operator():
+def test_nontrivial_diagonal_operator():
     x = (8.0, jnp.array([1, 2, 3]), {"a": jnp.array([4, 5]), "b": 6})
     y = (4.0, jnp.array([7, 8, 9]), {"a": jnp.array([2, 10]), "b": 12})
-    operator = lx.PyTreeDiagonalLinearOperator(x)
+    operator = lx.DiagonalLinearOperator(x)
     out = lx.linear_solve(operator, y).value
     true_out = (
         jnp.array(0.5),

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -48,6 +48,19 @@ def test_nontrivial_pytree_operator():
     assert tree_allclose(out, true_out)
 
 
+def test_nontrivial_pytree_diagonal_operator():
+    x = (8.0, jnp.array([1, 2, 3]), {"a": jnp.array([4, 5]), "b": 6})
+    y = (4.0, jnp.array([7, 8, 9]), {"a": jnp.array([2, 10]), "b": 12})
+    operator = lx.PyTreeDiagonalLinearOperator(x)
+    out = lx.linear_solve(operator, y).value
+    true_out = (
+        jnp.array(0.5),
+        jnp.array([7.0, 4.0, 3.0]),
+        {"a": jnp.array([0.5, 2.0]), "b": jnp.array(2.0)},
+    )
+    assert tree_allclose(out, true_out)
+
+
 @pytest.mark.parametrize("solver", (lx.LU(), lx.QR(), lx.SVD()))
 def test_mixed_dtypes(solver):
     f32 = lambda x: jnp.array(x, dtype=jnp.float32)


### PR DESCRIPTION
Adds a version of the diagonal linear operator that accepts and stores a PyTree.

Requesting main since dev does not exist at the moment :) 

As discussed in https://github.com/patrick-kidger/lineax/issues/124.