### PR TITLE
Iterative Solvers return successfully when run with `max_steps` only

### DIFF
--- a/lineax/_solver/bicgstab.py
+++ b/lineax/_solver/bicgstab.py
@@ -193,7 +193,7 @@ class BiCGStab(AbstractLinearSolver[_BiCGStabState], strict=True):
         else:
             result = RESULTS.where(
                 (num_steps == self.max_steps),
-                RESULTS.max_steps_reached,
+                RESULTS.max_steps_reached if has_scale else RESULTS.successful,
                 RESULTS.successful,
             )
         # breakdown is only an issue if we did not converge

--- a/lineax/_solver/cg.py
+++ b/lineax/_solver/cg.py
@@ -224,7 +224,7 @@ class _AbstractCG(AbstractLinearSolver[_CGState], strict=True):
         else:
             result = RESULTS.where(
                 num_steps == max_steps,
-                RESULTS.max_steps_reached,
+                RESULTS.max_steps_reached if has_scale else RESULTS.successful,
                 RESULTS.successful,
             )
 

--- a/lineax/_solver/gmres.py
+++ b/lineax/_solver/gmres.py
@@ -224,7 +224,7 @@ class GMRES(AbstractLinearSolver[_GMRESState], strict=True):
         else:
             result = RESULTS.where(
                 (num_steps == self.max_steps),
-                RESULTS.max_steps_reached,
+                RESULTS.max_steps_reached if has_scale else RESULTS.successful,
                 RESULTS.successful,
             )
         result = RESULTS.where(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -81,6 +81,15 @@ def construct_singular_matrix(getkey, solver, tags, num=1, dtype=jnp.float64):
             return tuple(matrix[:, 1:] for matrix in matrices)
 
 
+def construct_poisson_matrix(size, dtype=jnp.float64):
+    matrix = (
+        -2 * jnp.diag(jnp.ones(size, dtype=dtype))
+        + jnp.diag(jnp.ones(size - 1, dtype=dtype), 1)
+        + jnp.diag(jnp.ones(size - 1, dtype=dtype), -1)
+    )
+    return matrix
+
+
 if jax.config.jax_enable_x64:  # pyright: ignore
     tol = 1e-12
 else:

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -168,12 +168,12 @@ def test_grad_vmap_symbolic_cotangent():
     ),
 )
 def test_iterative_solver_max_steps_only(solver):
-    NUM_POINTS = 100
+    SIZE = 100
 
-    poisson_matrix = construct_poisson_matrix(NUM_POINTS)
+    poisson_matrix = construct_poisson_matrix(SIZE)
     poisson_operator = lx.MatrixLinearOperator(
         poisson_matrix, tags=(lx.negative_semidefinite_tag, lx.symmetric_tag)
     )
-    rhs = jax.random.normal(jax.random.key(0), (NUM_POINTS,))
+    rhs = jax.random.normal(jax.random.key(0), (SIZE,))
 
     lx.linear_solve(poisson_operator, rhs, solver)

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -168,6 +168,7 @@ def test_grad_vmap_symbolic_cotangent():
     ),
 )
 def test_iterative_solver_max_steps_only(solver):
+    """Iterative solvers should work with max_steps only (no Equinox errors)."""
     SIZE = 100
 
     poisson_matrix = construct_poisson_matrix(SIZE)


### PR DESCRIPTION
A simple modification in the iterative linear solvers to not throw an `Equinox Error` if run with only a prescribed `max_steps`, e.g., `rtol=0.0, atol=0.0, max_steps=5`.

Closes #126.