### PR TITLE
Implement NormalCholesky, cholesky solver applied to the normal equations

### DIFF
--- a/docs/api/solvers.md
+++ b/docs/api/solvers.md
@@ -42,6 +42,13 @@ These are capable of solving ill-posed linear problems.
         members:
             - __init__
 
+---
+
+::: lineax.NormalCholesky
+    options:
+        members:
+            - __init__
+
 !!! info
 
     In addition to these, `lineax.Diagonal(well_posed=False)` and [`lineax.NormalCG`][] (below) also support ill-posed problems.

--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -60,6 +60,7 @@ from ._solver import (
     GMRES as GMRES,
     LU as LU,
     NormalCG as NormalCG,
+    NormalCholesky as NormalCholesky,
     QR as QR,
     SVD as SVD,
     Triangular as Triangular,

--- a/lineax/_solver/__init__.py
+++ b/lineax/_solver/__init__.py
@@ -14,7 +14,7 @@
 
 from .bicgstab import BiCGStab as BiCGStab
 from .cg import CG as CG, NormalCG as NormalCG
-from .cholesky import Cholesky as Cholesky
+from .cholesky import Cholesky as Cholesky, NormalCholesky as NormalCholesky
 from .diagonal import Diagonal as Diagonal
 from .gmres import GMRES as GMRES
 from .lu import LU as LU

--- a/lineax/_solver/cg.py
+++ b/lineax/_solver/cg.py
@@ -109,7 +109,7 @@ class _AbstractCG(AbstractLinearSolver[_CGState]):
             # If a downstream user wants to avoid this then they can call
             # ```
             # linear_solve(
-            #     conj(operator.T) @ operator, operator.mv(b), solver=CG()
+            #     conj(operator.T) @ operator, conj(operator.T).mv(b), solver=CG()
             # )
             # ```
             # directly.
@@ -280,7 +280,7 @@ class CG(_AbstractCG):
 class NormalCG(_AbstractCG):
     """Conjugate gradient applied to the normal equations:
 
-    `A^T A = A^T b`
+    `A^T A x = A^T b`
 
     of a system of linear equations. Note that this squares the condition
     number, so it is not recommended. This is a fast but potentially inaccurate

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -115,6 +115,7 @@ solvers_tags_pseudoinverse = [
     (lx.NormalCG(rtol=tol, atol=tol), lx.negative_semidefinite_tag, False),
     (lx.Cholesky(), lx.positive_semidefinite_tag, False),
     (lx.Cholesky(), lx.negative_semidefinite_tag, False),
+    (lx.NormalCholesky(), (), False),
 ]
 solvers_tags = [(a, b) for a, b, _ in solvers_tags_pseudoinverse]
 solvers = [a for a, _, _ in solvers_tags_pseudoinverse]

--- a/tests/test_singular.py
+++ b/tests/test_singular.py
@@ -101,7 +101,8 @@ def test_gmres_stagnation_or_breakdown(getkey, dtype):
 
 
 @pytest.mark.parametrize(
-    "solver", (lx.AutoLinearSolver(well_posed=None), lx.QR(), lx.SVD())
+    "solver",
+    (lx.AutoLinearSolver(well_posed=None), lx.QR(), lx.SVD(), lx.NormalCholesky()),
 )
 def test_nonsquare_pytree_operator1(solver):
     x = [[1, 5.0, jnp.array(-1.0)], [jnp.array(-2), jnp.array(-2.0), 3.0]]
@@ -116,7 +117,8 @@ def test_nonsquare_pytree_operator1(solver):
 
 
 @pytest.mark.parametrize(
-    "solver", (lx.AutoLinearSolver(well_posed=None), lx.QR(), lx.SVD())
+    "solver",
+    (lx.AutoLinearSolver(well_posed=None), lx.QR(), lx.SVD(), lx.NormalCholesky()),
 )
 def test_nonsquare_pytree_operator2(solver):
     x = [[1, jnp.array(-2)], [5.0, jnp.array(-2.0)], [jnp.array(-1.0), 3.0]]


### PR DESCRIPTION
Here is the obvious implementation of Cholesky applied to the normal equations for solving full rank non-square systems.  This solves the same set of problems as unpivoted QR, but can sometimes be much faster, and I understand it may batch better than current qr implementations in some jax contexts. It needs to be implemented as a lineax solver, as opposed to by the user so it can 1) make use of lineax's jvp, and 2) be used in contexts where a lineax solver is needed, eg in optimistix routines. 