### PR TITLE
Replace allow_dependent_rows and allow_dependent_columns with assume_full_rank

### DIFF
--- a/docs/api/solvers.md
+++ b/docs/api/solvers.md
@@ -9,9 +9,9 @@ If you're not sure what to use, then pick [`lineax.AutoLinearSolver`][] and it w
             members:
                 - init
                 - compute
-                - allow_dependent_columns
-                - allow_dependent_rows
                 - transpose
+                - conj
+                - assume_full_rank
 
 ::: lineax.AutoLinearSolver
     options:

--- a/lineax/_solver/bicgstab.py
+++ b/lineax/_solver/bicgstab.py
@@ -216,11 +216,8 @@ class BiCGStab(AbstractLinearSolver[_BiCGStabState]):
         conj_options = {}
         return conj(operator), conj_options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 BiCGStab.__init__.__doc__ = r"""**Arguments:**

--- a/lineax/_solver/cg.py
+++ b/lineax/_solver/cg.py
@@ -270,11 +270,8 @@ class CG(_AbstractCG):
 
     _normal: ClassVar[bool] = False
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 class NormalCG(_AbstractCG):
@@ -304,15 +301,8 @@ class NormalCG(_AbstractCG):
 
     _normal: ClassVar[bool] = True
 
-    def allow_dependent_columns(self, operator):
-        rows = operator.out_size()
-        columns = operator.in_size()
-        return columns > rows
-
-    def allow_dependent_rows(self, operator):
-        rows = operator.out_size()
-        columns = operator.in_size()
-        return rows > columns
+    def assume_full_rank(self):
+        return True
 
 
 CG.__init__.__doc__ = r"""**Arguments:**

--- a/lineax/_solver/cholesky.py
+++ b/lineax/_solver/cholesky.py
@@ -85,11 +85,8 @@ class Cholesky(AbstractLinearSolver[_CholeskyState]):
         factor, is_nsd = state
         return (factor.conj(), is_nsd), options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 Cholesky.__init__.__doc__ = """**Arguments:**

--- a/lineax/_solver/diagonal.py
+++ b/lineax/_solver/diagonal.py
@@ -101,11 +101,8 @@ class Diagonal(AbstractLinearSolver[_DiagonalState]):
         conj_state = conj_diag, packed_structures
         return conj_state, conj_options
 
-    def allow_dependent_columns(self, operator):
-        return not self.well_posed
-
-    def allow_dependent_rows(self, operator):
-        return not self.well_posed
+    def assume_full_rank(self):
+        return self.well_posed
 
 
 Diagonal.__init__.__doc__ = """**Arguments**:

--- a/lineax/_solver/gmres.py
+++ b/lineax/_solver/gmres.py
@@ -425,11 +425,8 @@ class GMRES(AbstractLinearSolver[_GMRESState]):
         conj_options = {}
         return conj(operator), conj_options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 GMRES.__init__.__doc__ = r"""**Arguments:**

--- a/lineax/_solver/lu.py
+++ b/lineax/_solver/lu.py
@@ -84,11 +84,8 @@ class LU(AbstractLinearSolver[_LUState]):
         conj_options = {}
         return conj_state, conj_options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 LU.__init__.__doc__ = """**Arguments:**

--- a/lineax/_solver/qr.py
+++ b/lineax/_solver/qr.py
@@ -100,22 +100,8 @@ class QR(AbstractLinearSolver):
         conj_options = {}
         return conj_state, conj_options
 
-    def allow_dependent_columns(self, operator):
-        rows = operator.out_size()
-        columns = operator.in_size()
-        # We're able to pull an efficiency trick here.
-        #
-        # As we don't use a rank-revealing implementation, then we always require that
-        # the operator have full rank.
-        #
-        # So if we have columns <= rows, then we know that all our columns are linearly
-        # independent. We can return `False` and get a computationally cheaper jvp rule.
-        return columns > rows
-
-    def allow_dependent_rows(self, operator):
-        rows = operator.out_size()
-        columns = operator.in_size()
-        return rows > columns
+    def assume_full_rank(self):
+        return True
 
 
 QR.__init__.__doc__ = """**Arguments:**

--- a/lineax/_solver/svd.py
+++ b/lineax/_solver/svd.py
@@ -92,11 +92,8 @@ class SVD(AbstractLinearSolver[_SVDState]):
         conj_options = {}
         return conj_state, conj_options
 
-    def allow_dependent_columns(self, operator):
-        return True
-
-    def allow_dependent_rows(self, operator):
-        return True
+    def assume_full_rank(self):
+        return False
 
 
 SVD.__init__.__doc__ = """**Arguments**:

--- a/lineax/_solver/triangular.py
+++ b/lineax/_solver/triangular.py
@@ -103,11 +103,8 @@ class Triangular(AbstractLinearSolver[_TriangularState]):
         conj_options = {}
         return conj_state, conj_options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 Triangular.__init__.__doc__ = """**Arguments:**

--- a/lineax/_solver/tridiagonal.py
+++ b/lineax/_solver/tridiagonal.py
@@ -84,11 +84,8 @@ class Tridiagonal(AbstractLinearSolver[_TridiagonalState]):
         conj_state = (conj_diagonals, packed_structures)
         return conj_state, options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 Tridiagonal.__init__.__doc__ = """**Arguments:**


### PR DESCRIPTION

The two functions allow_dependent_{rows,columns} together did the job of answering if the solver accepts full rank matrices for the purposes of the jvp. Allowing them to be implemented separately created some issues: 
1) Invalid states were representable. Eg. What does it mean that
   dependent columns are allowed for square matrices if dependent rows
   are not? What does it mean that dependent rows are not allowed for
   matrices with more rows than columns?
2) As the functions accept operator as input, a custom solver could in
   principle decide its answer based on operator's dynamic value rather
   than only jax compilation static information regarding it, as in all
   the lineax defined solvers. This would prevent jax compilation and
   jit.

Both issues are addressed by asking the solver to report only if it assumes the input is numerically full rank. If this assumption is exactly violated, its behavior is allowed to be undefined, and is allowed to error, produce NaN values, and produce invalid values.