### PR TITLE
Implement Normal, a solver applying an inner solver to the normal equations

### DIFF
--- a/docs/api/solvers.md
+++ b/docs/api/solvers.md
@@ -9,9 +9,9 @@ If you're not sure what to use, then pick [`lineax.AutoLinearSolver`][] and it w
             members:
                 - init
                 - compute
-                - allow_dependent_columns
-                - allow_dependent_rows
                 - transpose
+                - conj
+                - assume_full_rank
 
 ::: lineax.AutoLinearSolver
     options:

--- a/docs/api/solvers.md
+++ b/docs/api/solvers.md
@@ -42,9 +42,16 @@ These are capable of solving ill-posed linear problems.
         members:
             - __init__
 
+---
+
+::: lineax.Normal
+    options:
+        members:
+            - __init__
+
 !!! info
 
-    In addition to these, `lineax.Diagonal(well_posed=False)` and [`lineax.NormalCG`][] (below) also support ill-posed problems.
+    In addition to these, `lineax.Diagonal(well_posed=False)` (below) also supports ill-posed problems.
 
 ## Structure-exploiting solvers
 
@@ -89,13 +96,6 @@ These solvers use only matrix-vector products, and do not require instantiating 
     Note that [`lineax.BiCGStab`][] and [`lineax.GMRES`][] may fail to converge on some (typically non-sparse) problems.
 
 ::: lineax.CG
-    options:
-        members:
-            - __init__
-
----
-
-::: lineax.NormalCG
     options:
         members:
             - __init__

--- a/docs/examples/no_materialisation.ipynb
+++ b/docs/examples/no_materialisation.ipynb
@@ -54,7 +54,7 @@
     "y = jnp.array([1.0, 2.0, 3.0])\n",
     "operator = lx.JacobianLinearOperator(f, y, args=None)\n",
     "vector = f(y, args=None)\n",
-    "solver = lx.NormalCG(rtol=1e-6, atol=1e-6)\n",
+    "solver = lx.Normal(lx.CG(rtol=1e-6, atol=1e-6))\n",
     "solution = lx.linear_solve(operator, vector, solver)"
    ]
   },

--- a/lineax/__init__.py
+++ b/lineax/__init__.py
@@ -59,7 +59,7 @@ from ._solver import (
     Diagonal as Diagonal,
     GMRES as GMRES,
     LU as LU,
-    NormalCG as NormalCG,
+    Normal as Normal,
     QR as QR,
     SVD as SVD,
     Triangular as Triangular,

--- a/lineax/_solver/__init__.py
+++ b/lineax/_solver/__init__.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 from .bicgstab import BiCGStab as BiCGStab
-from .cg import CG as CG, NormalCG as NormalCG
+from .cg import CG as CG
 from .cholesky import Cholesky as Cholesky
 from .diagonal import Diagonal as Diagonal
 from .gmres import GMRES as GMRES
 from .lu import LU as LU
+from .normal import Normal as Normal
 from .qr import QR as QR
 from .svd import SVD as SVD
 from .triangular import Triangular as Triangular

--- a/lineax/_solver/bicgstab.py
+++ b/lineax/_solver/bicgstab.py
@@ -216,11 +216,8 @@ class BiCGStab(AbstractLinearSolver[_BiCGStabState]):
         conj_options = {}
         return conj(operator), conj_options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 BiCGStab.__init__.__doc__ = r"""**Arguments:**

--- a/lineax/_solver/cg.py
+++ b/lineax/_solver/cg.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Callable
-from typing import Any, ClassVar, TYPE_CHECKING, TypeAlias
+from typing import Any, TYPE_CHECKING, TypeAlias
 
 import equinox.internal as eqxi
 import jax
@@ -25,9 +25,9 @@ from jaxtyping import Array, PyTree, Scalar
 
 
 if TYPE_CHECKING:
-    from typing import ClassVar as AbstractClassVar
+    pass
 else:
-    from equinox.internal import AbstractClassVar
+    pass
 
 from .._misc import resolve_rcond, structure_equal, tree_where
 from .._norm import max_norm, tree_dot
@@ -50,14 +50,29 @@ _CGState: TypeAlias = tuple[AbstractLinearOperator, bool]
 # - CG evaluates `operator.mv` three times.
 # - Normal CG evaluates `operator.mv` seven (!) times.
 # Possibly this can be cheapened a bit somehow?
-class _AbstractCG(AbstractLinearSolver[_CGState]):
+class CG(AbstractLinearSolver[_CGState]):
+    """Conjugate gradient solver for linear systems.
+
+    The operator should be positive or negative definite.
+
+    Equivalent to `scipy.sparse.linalg.cg`.
+
+    This supports the following `options` (as passed to
+    `lx.linear_solve(..., options=...)`).
+
+    - `preconditioner`: A positive definite [`lineax.AbstractLinearOperator`][]
+        to be used as preconditioner. Defaults to
+        [`lineax.IdentityLinearOperator`][].
+    - `y0`: The initial estimate of the solution to the linear system. Defaults to all
+        zeros.
+
+    """
+
     rtol: float
     atol: float
     norm: Callable[[PyTree], Scalar] = max_norm
     stabilise_every: int | None = 10
     max_steps: int | None = None
-
-    _normal: AbstractClassVar[bool]
 
     def __check_init__(self):
         if isinstance(self.rtol, (int, float)) and self.rtol < 0:
@@ -75,18 +90,18 @@ class _AbstractCG(AbstractLinearSolver[_CGState]):
     def init(self, operator: AbstractLinearOperator, options: dict[str, Any]):
         del options
         is_nsd = is_negative_semidefinite(operator)
-        if not self._normal:
-            if not structure_equal(operator.in_structure(), operator.out_structure()):
-                raise ValueError(
-                    "`CG()` may only be used for linear solves with " "square matrices."
-                )
-            if not (is_positive_semidefinite(operator) | is_nsd):
-                raise ValueError(
-                    "`CG()` may only be used for positive "
-                    "or negative definite linear operators"
-                )
-            if is_nsd:
-                operator = -operator
+        if not structure_equal(operator.in_structure(), operator.out_structure()):
+            raise ValueError(
+                "`CG()` may only be used for linear solves with " "square matrices."
+            )
+        if not (is_positive_semidefinite(operator) | is_nsd):
+            raise ValueError(
+                "`CG()` may only be used for positive "
+                "or negative definite linear operators"
+            )
+        if is_nsd:
+            operator = -operator
+        operator = linearise(operator)
         return operator, is_nsd
 
     # This differs from jax.scipy.sparse.linalg.cg in:
@@ -102,28 +117,6 @@ class _AbstractCG(AbstractLinearSolver[_CGState]):
         self, state: _CGState, vector: PyTree[Array], options: dict[str, Any]
     ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
         operator, is_nsd = state
-        if self._normal:
-            # Linearise if JacobianLinearOperator, to avoid computing the forward
-            # pass separately for mv and transpose_mv.
-            # This choice is "fast by default", even at the expense of memory.
-            # If a downstream user wants to avoid this then they can call
-            # ```
-            # linear_solve(
-            #     conj(operator.T) @ operator, operator.mv(b), solver=CG()
-            # )
-            # ```
-            # directly.
-            operator = linearise(operator)
-
-            _mv = operator.mv
-            _transpose_mv = conj(operator.transpose()).mv
-
-            def mv(vector: PyTree) -> PyTree:
-                return _transpose_mv(_mv(vector))
-
-            vector = _transpose_mv(vector)
-        else:
-            mv = operator.mv
         preconditioner, y0 = preconditioner_and_y0(operator, vector, options)
         leaves, _ = jtu.tree_flatten(vector)
         size = sum(leaf.size for leaf in leaves)
@@ -131,7 +124,7 @@ class _AbstractCG(AbstractLinearSolver[_CGState]):
             max_steps = 10 * size  # Copied from SciPy!
         else:
             max_steps = self.max_steps
-        r0 = (vector**ω - mv(y0) ** ω).ω
+        r0 = (vector**ω - operator.mv(y0) ** ω).ω
         p0 = preconditioner.mv(r0)
         gamma0 = tree_dot(p0, r0)
         rcond = resolve_rcond(None, size, size, jnp.result_type(*leaves))
@@ -174,7 +167,7 @@ class _AbstractCG(AbstractLinearSolver[_CGState]):
 
         def body_fun(value):
             _, y, r, p, gamma, step = value
-            mat_p = mv(p)
+            mat_p = operator.mv(p)
             inner_prod = tree_dot(mat_p, p)
             alpha = gamma / inner_prod
             alpha = tree_where(
@@ -189,7 +182,7 @@ class _AbstractCG(AbstractLinearSolver[_CGState]):
             # We compute the residual the "expensive" way every now and again, so as to
             # correct numerical rounding errors.
             def stable_r():
-                return (vector**ω - mv(y) ** ω).ω
+                return (vector**ω - operator.mv(y) ** ω).ω
 
             def cheap_r():
                 return (r**ω - alpha * mat_p**ω).ω
@@ -227,7 +220,7 @@ class _AbstractCG(AbstractLinearSolver[_CGState]):
                 RESULTS.successful,
             )
 
-        if is_nsd and not self._normal:
+        if is_nsd:
             solution = -(solution**ω).ω
         stats = {"num_steps": num_steps, "max_steps": self.max_steps}
         return solution, result, stats
@@ -246,83 +239,11 @@ class _AbstractCG(AbstractLinearSolver[_CGState]):
         conj_options = {}
         return conj_state, conj_options
 
-
-class CG(_AbstractCG):
-    """Conjugate gradient solver for linear systems.
-
-    The operator should be positive or negative definite.
-
-    Equivalent to `scipy.sparse.linalg.cg`.
-
-    This supports the following `options` (as passed to
-    `lx.linear_solve(..., options=...)`).
-
-    - `preconditioner`: A positive definite [`lineax.AbstractLinearOperator`][]
-        to be used as preconditioner. Defaults to
-        [`lineax.IdentityLinearOperator`][].
-    - `y0`: The initial estimate of the solution to the linear system. Defaults to all
-        zeros.
-
-    !!! info
-
-
-    """
-
-    _normal: ClassVar[bool] = False
-
-    def assume_full_rank(self):
-        return True
-
-
-class NormalCG(_AbstractCG):
-    """Conjugate gradient applied to the normal equations:
-
-    `A^T A = A^T b`
-
-    of a system of linear equations. Note that this squares the condition
-    number, so it is not recommended. This is a fast but potentially inaccurate
-    method, especially in 32 bit floating point precision.
-
-    This can handle nonsquare operators provided they are full-rank.
-
-    This supports the following `options` (as passed to
-    `lx.linear_solve(..., options=...)`).
-
-    - `preconditioner`: A positive definite [`lineax.AbstractLinearOperator`][]
-        to be used as preconditioner. Defaults to
-        [`lineax.IdentityLinearOperator`][].
-    - `y0`: The initial estimate of the solution to the linear system. Defaults to all
-        zeros.
-
-    !!! info
-
-
-    """
-
-    _normal: ClassVar[bool] = True
-
     def assume_full_rank(self):
         return True
 
 
 CG.__init__.__doc__ = r"""**Arguments:**
-
-- `rtol`: Relative tolerance for terminating solve.
-- `atol`: Absolute tolerance for terminating solve.
-- `norm`: The norm to use when computing whether the error falls within the tolerance.
-    Defaults to the max norm.
-- `stabilise_every`: The conjugate gradient is an iterative method that produces
-    candidate solutions $x_1, x_2, \ldots$, and terminates once $r_i = \| Ax_i - b \|$
-    is small enough. For computational efficiency, the values $r_i$ are computed using
-    other internal quantities, and not by directly evaluating the formula above.
-    However, this computation of $r_i$ is susceptible to drift due to limited
-    floating-point precision. Every `stabilise_every` steps, then $r_i$ is computed
-    directly using the formula above, in order to stabilise the computation.
-- `max_steps`: The maximum number of iterations to run the solver for. If more steps
-    than this are required, then the solve is halted with a failure.
-"""
-
-NormalCG.__init__.__doc__ = r"""**Arguments:**
 
 - `rtol`: Relative tolerance for terminating solve.
 - `atol`: Absolute tolerance for terminating solve.

--- a/lineax/_solver/cg.py
+++ b/lineax/_solver/cg.py
@@ -270,11 +270,8 @@ class CG(_AbstractCG):
 
     _normal: ClassVar[bool] = False
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 class NormalCG(_AbstractCG):
@@ -304,15 +301,8 @@ class NormalCG(_AbstractCG):
 
     _normal: ClassVar[bool] = True
 
-    def allow_dependent_columns(self, operator):
-        rows = operator.out_size()
-        columns = operator.in_size()
-        return columns > rows
-
-    def allow_dependent_rows(self, operator):
-        rows = operator.out_size()
-        columns = operator.in_size()
-        return rows > columns
+    def assume_full_rank(self):
+        return True
 
 
 CG.__init__.__doc__ = r"""**Arguments:**

--- a/lineax/_solver/cholesky.py
+++ b/lineax/_solver/cholesky.py
@@ -57,7 +57,7 @@ class Cholesky(AbstractLinearSolver[_CholeskyState]):
         if is_nsd:
             matrix = -matrix
         factor, lower = jsp.linalg.cho_factor(matrix)
-        # Fix lower triangular for simplicity.
+        # Fix upper triangular for simplicity.
         assert lower is False
         return factor, is_nsd
 

--- a/lineax/_solver/cholesky.py
+++ b/lineax/_solver/cholesky.py
@@ -85,11 +85,8 @@ class Cholesky(AbstractLinearSolver[_CholeskyState]):
         factor, is_nsd = state
         return (factor.conj(), is_nsd), options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 Cholesky.__init__.__doc__ = """**Arguments:**

--- a/lineax/_solver/diagonal.py
+++ b/lineax/_solver/diagonal.py
@@ -101,11 +101,8 @@ class Diagonal(AbstractLinearSolver[_DiagonalState]):
         conj_state = conj_diag, packed_structures
         return conj_state, conj_options
 
-    def allow_dependent_columns(self, operator):
-        return not self.well_posed
-
-    def allow_dependent_rows(self, operator):
-        return not self.well_posed
+    def assume_full_rank(self):
+        return self.well_posed
 
 
 Diagonal.__init__.__doc__ = """**Arguments**:

--- a/lineax/_solver/gmres.py
+++ b/lineax/_solver/gmres.py
@@ -425,11 +425,8 @@ class GMRES(AbstractLinearSolver[_GMRESState]):
         conj_options = {}
         return conj(operator), conj_options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 GMRES.__init__.__doc__ = r"""**Arguments:**

--- a/lineax/_solver/lu.py
+++ b/lineax/_solver/lu.py
@@ -84,11 +84,8 @@ class LU(AbstractLinearSolver[_LUState]):
         conj_options = {}
         return conj_state, conj_options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 LU.__init__.__doc__ = """**Arguments:**

--- a/lineax/_solver/normal.py
+++ b/lineax/_solver/normal.py
@@ -1,0 +1,131 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, TypeVar
+
+from jaxtyping import Array, PyTree
+
+from .._operator import (
+    conj,
+    TaggedLinearOperator,
+)
+from .._solution import RESULTS
+from .._solve import AbstractLinearOperator, AbstractLinearSolver
+from .._tags import positive_semidefinite_tag
+
+
+_InnerSolverState = TypeVar("_InnerSolverState")
+# _NormalState: TypeAlias = tuple[_InnerSolverState, bool, AbstractLinearOperator]
+
+
+class Normal(
+    # AbstractLinearSolver[_NormalState]
+    AbstractLinearSolver[tuple[_InnerSolverState, bool, AbstractLinearOperator]]
+):
+    """Wrapper for an inner solver of positive (semi)definite systems. The
+    wrapped solver handles possible nonsquare systems $Ax = b$ by applying the
+    inner solver to the normal equations
+
+    $A^* A x = A^* b$
+
+    if $m \\ge n$, otherwise
+
+    $A A^* y = b$,
+
+    where $x = A^* y$.
+
+    If the inner solver solves systems with positive definite $A$, the wrapped
+    solver solves systems with full rank $A$.
+
+    If the inner solver solves systems with positive semidefinite $A$, the
+    wrapped solver solves systems with arbitrary, possibly rank deficient, $A$.
+
+    Note that this squares the condition number, so it is not recommended. This
+    is a fast but potentially inaccurate method, especially in 32 bit floating
+    point precision.
+
+    !!! Info
+
+        Good choices of inner solvers are the direct [`lineax.Cholesky`][] and
+        the iterative [`lineax.CG`][].
+
+    """
+
+    inner_solver: AbstractLinearSolver[_InnerSolverState]
+
+    def init(self, operator, options):
+        tall = operator.out_size() >= operator.in_size()
+        if tall:
+            inner_operator = conj(operator.transpose()) @ operator
+        else:
+            inner_operator = operator @ conj(operator.transpose())
+        inner_operator = TaggedLinearOperator(inner_operator, positive_semidefinite_tag)
+        inner_state = self.inner_solver.init(inner_operator, options)
+        operator_conj_transpose = conj(operator.transpose())
+        return inner_state, tall, operator_conj_transpose
+
+    def compute(
+        self,
+        state: tuple[_InnerSolverState, bool, AbstractLinearOperator],
+        vector: PyTree[Array],
+        options: dict[str, Any],
+    ) -> tuple[PyTree[Array], RESULTS, dict[str, Any]]:
+        inner_state, tall, operator_conj_transpose = state
+        del state
+        if tall:
+            vector = operator_conj_transpose.mv(vector)
+        solution, result, extra_stats = self.inner_solver.compute(
+            inner_state, vector, options
+        )
+        if not tall:
+            solution = operator_conj_transpose.mv(solution)
+        return solution, result, extra_stats
+
+    def transpose(
+        self,
+        state: tuple[_InnerSolverState, bool, AbstractLinearOperator],
+        options: dict[str, Any],
+    ):
+        inner_state, tall, operator_conj_transpose = state
+        inner_state_conj, options = self.inner_solver.conj(inner_state, options)
+        state_transpose = (
+            inner_state_conj,
+            not tall,
+            operator_conj_transpose.transpose(),
+        )
+        return state_transpose, options
+
+    def conj(
+        self,
+        state: tuple[_InnerSolverState, bool, AbstractLinearOperator],
+        options: dict[str, Any],
+    ):
+        inner_state, tall, operator_conj_transpose = state
+        inner_state_conj, options = self.inner_solver.conj(inner_state, options)
+        state_conj = (
+            inner_state_conj,
+            tall,
+            conj(operator_conj_transpose),
+        )
+        return state_conj, options
+
+    def assume_full_rank(self):
+        return self.inner_solver.assume_full_rank()
+
+
+Normal.__init__.__doc__ = """**Arguments:**
+
+- `inner_solver`: The solver to wrap. It should support solving positive
+  definite systems or positive semidefinite systems
+"""

--- a/lineax/_solver/qr.py
+++ b/lineax/_solver/qr.py
@@ -100,22 +100,8 @@ class QR(AbstractLinearSolver):
         conj_options = {}
         return conj_state, conj_options
 
-    def allow_dependent_columns(self, operator):
-        rows = operator.out_size()
-        columns = operator.in_size()
-        # We're able to pull an efficiency trick here.
-        #
-        # As we don't use a rank-revealing implementation, then we always require that
-        # the operator have full rank.
-        #
-        # So if we have columns <= rows, then we know that all our columns are linearly
-        # independent. We can return `False` and get a computationally cheaper jvp rule.
-        return columns > rows
-
-    def allow_dependent_rows(self, operator):
-        rows = operator.out_size()
-        columns = operator.in_size()
-        return rows > columns
+    def assume_full_rank(self):
+        return True
 
 
 QR.__init__.__doc__ = """**Arguments:**

--- a/lineax/_solver/svd.py
+++ b/lineax/_solver/svd.py
@@ -92,11 +92,8 @@ class SVD(AbstractLinearSolver[_SVDState]):
         conj_options = {}
         return conj_state, conj_options
 
-    def allow_dependent_columns(self, operator):
-        return True
-
-    def allow_dependent_rows(self, operator):
-        return True
+    def assume_full_rank(self):
+        return False
 
 
 SVD.__init__.__doc__ = """**Arguments**:

--- a/lineax/_solver/triangular.py
+++ b/lineax/_solver/triangular.py
@@ -103,11 +103,8 @@ class Triangular(AbstractLinearSolver[_TriangularState]):
         conj_options = {}
         return conj_state, conj_options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 Triangular.__init__.__doc__ = """**Arguments:**

--- a/lineax/_solver/tridiagonal.py
+++ b/lineax/_solver/tridiagonal.py
@@ -84,11 +84,8 @@ class Tridiagonal(AbstractLinearSolver[_TridiagonalState]):
         conj_state = (conj_diagonals, packed_structures)
         return conj_state, options
 
-    def allow_dependent_columns(self, operator):
-        return False
-
-    def allow_dependent_rows(self, operator):
-        return False
+    def assume_full_rank(self):
+        return True
 
 
 Tridiagonal.__init__.__doc__ = """**Arguments:**

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -57,7 +57,7 @@ def _construct_matrix_impl(getkey, cond_cutoff, tags, size, dtype, i):
 
 
 def construct_matrix(getkey, solver, tags, num=1, *, size=3, dtype=jnp.float64):
-    if isinstance(solver, lx.NormalCG):
+    if isinstance(solver, lx.Normal):
         cond_cutoff = math.sqrt(1000)
     else:
         cond_cutoff = 1000
@@ -109,12 +109,12 @@ solvers_tags_pseudoinverse = [
     (lx.SVD(), (), True),
     (lx.BiCGStab(rtol=tol, atol=tol), (), False),
     (lx.GMRES(rtol=tol, atol=tol), (), False),
-    (lx.NormalCG(rtol=tol, atol=tol), (), False),
     (lx.CG(rtol=tol, atol=tol), lx.positive_semidefinite_tag, False),
     (lx.CG(rtol=tol, atol=tol), lx.negative_semidefinite_tag, False),
-    (lx.NormalCG(rtol=tol, atol=tol), lx.negative_semidefinite_tag, False),
     (lx.Cholesky(), lx.positive_semidefinite_tag, False),
     (lx.Cholesky(), lx.negative_semidefinite_tag, False),
+    (lx.Normal(lx.Cholesky()), (), False),
+    (lx.Normal(lx.CG(rtol=tol, atol=tol)), (), False),
 ]
 solvers_tags = [(a, b) for a, b, _ in solvers_tags_pseudoinverse]
 solvers = [a for a, _, _ in solvers_tags_pseudoinverse]

--- a/tests/test_singular.py
+++ b/tests/test_singular.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import functools as ft
 
 import equinox as eqx
@@ -101,7 +100,14 @@ def test_gmres_stagnation_or_breakdown(getkey, dtype):
 
 
 @pytest.mark.parametrize(
-    "solver", (lx.AutoLinearSolver(well_posed=None), lx.QR(), lx.SVD())
+    "solver",
+    (
+        lx.AutoLinearSolver(well_posed=None),
+        lx.QR(),
+        lx.SVD(),
+        lx.Normal(lx.Cholesky()),
+        lx.Normal(lx.SVD()),
+    ),
 )
 def test_nonsquare_pytree_operator1(solver):
     x = [[1, 5.0, jnp.array(-1.0)], [jnp.array(-2), jnp.array(-2.0), 3.0]]
@@ -116,7 +122,14 @@ def test_nonsquare_pytree_operator1(solver):
 
 
 @pytest.mark.parametrize(
-    "solver", (lx.AutoLinearSolver(well_posed=None), lx.QR(), lx.SVD())
+    "solver",
+    (
+        lx.AutoLinearSolver(well_posed=None),
+        lx.QR(),
+        lx.SVD(),
+        lx.Normal(lx.Cholesky()),
+        lx.Normal(lx.SVD()),
+    ),
 )
 def test_nonsquare_pytree_operator2(solver):
     x = [[1, jnp.array(-2)], [5.0, jnp.array(-2.0)], [jnp.array(-1.0), 3.0]]
@@ -130,11 +143,21 @@ def test_nonsquare_pytree_operator2(solver):
     assert tree_allclose(out, true_out)
 
 
+@pytest.mark.parametrize(
+    "solver",
+    (
+        lx.AutoLinearSolver(well_posed=None),
+        lx.QR(),
+        lx.SVD(),
+        lx.Normal(lx.Cholesky()),
+        lx.Normal(lx.SVD()),
+    ),
+)
 @pytest.mark.parametrize("full_rank", (True, False))
 @pytest.mark.parametrize("jvp", (False, True))
 @pytest.mark.parametrize("wide", (False, True))
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
-def test_qr_nonsquare_mat_vec(full_rank, jvp, wide, dtype, getkey):
+def test_nonsquare_mat_vec(solver, full_rank, jvp, wide, dtype, getkey):
     if wide:
         out_size = 3
         in_size = 6
@@ -142,39 +165,49 @@ def test_qr_nonsquare_mat_vec(full_rank, jvp, wide, dtype, getkey):
         out_size = 6
         in_size = 3
     matrix = jr.normal(getkey(), (out_size, in_size), dtype=dtype)
-    if full_rank:
-        context = contextlib.nullcontext()
-    else:
-        context = pytest.raises(Exception)
-        if wide:
-            matrix = matrix.at[:, 2:].set(0)
-        else:
-            matrix = matrix.at[2:, :].set(0)
+    if not full_rank:
+        if solver.assume_full_rank():
+            return
+        # nontrivial rank 2 sparsity pattern
+        matrix = matrix.at[1:, 1:].set(0)
     vector = jr.normal(getkey(), (out_size,), dtype=dtype)
     lx_solve = lambda mat, vec: lx.linear_solve(
-        lx.MatrixLinearOperator(mat), vec, lx.QR()
+        lx.MatrixLinearOperator(mat), vec, solver
     ).value
     jnp_solve = lambda mat, vec: jnp.linalg.lstsq(mat, vec)[0]  # pyright: ignore
     if jvp:
         lx_solve = eqx.filter_jit(ft.partial(eqx.filter_jvp, lx_solve))
         jnp_solve = eqx.filter_jit(ft.partial(finite_difference_jvp, jnp_solve))
         t_matrix = jr.normal(getkey(), (out_size, in_size), dtype=dtype)
+        if not full_rank:
+            # t_matrix must be chosen tangent to the manifold of rank 2
+            # matrices at matrix. A simple way to achieve this is to make the
+            # same restriction as we did to matrix
+            t_matrix = t_matrix.at[1:, 1:].set(0)
         t_vector = jr.normal(getkey(), (out_size,), dtype=dtype)
         args = ((matrix, vector), (t_matrix, t_vector))
     else:
         args = (matrix, vector)
-    with context:
-        x = lx_solve(*args)  # pyright: ignore
-    if full_rank:
-        true_x = jnp_solve(*args)
-        assert tree_allclose(x, true_x, atol=1e-4, rtol=1e-4)
+    x = lx_solve(*args)  # pyright: ignore
+    true_x = jnp_solve(*args)
+    assert tree_allclose(x, true_x, atol=1e-4, rtol=1e-4)
 
 
+@pytest.mark.parametrize(
+    "solver",
+    (
+        lx.AutoLinearSolver(well_posed=None),
+        lx.QR(),
+        lx.SVD(),
+        lx.Normal(lx.Cholesky()),
+        lx.Normal(lx.SVD()),
+    ),
+)
 @pytest.mark.parametrize("full_rank", (True, False))
 @pytest.mark.parametrize("jvp", (False, True))
 @pytest.mark.parametrize("wide", (False, True))
 @pytest.mark.parametrize("dtype", (jnp.float64, jnp.complex128))
-def test_qr_nonsquare_vec(full_rank, jvp, wide, dtype, getkey):
+def test_nonsquare_vec(solver, full_rank, jvp, wide, dtype, getkey):
     if wide:
         out_size = 3
         in_size = 6
@@ -182,17 +215,14 @@ def test_qr_nonsquare_vec(full_rank, jvp, wide, dtype, getkey):
         out_size = 6
         in_size = 3
     matrix = jr.normal(getkey(), (out_size, in_size), dtype=dtype)
-    if full_rank:
-        context = contextlib.nullcontext()
-    else:
-        context = pytest.raises(Exception)
-        if wide:
-            matrix = matrix.at[:, 2:].set(0)
-        else:
-            matrix = matrix.at[2:, :].set(0)
+    if not full_rank:
+        if solver.assume_full_rank():
+            return
+        # nontrivial rank 2 sparsity pattern
+        matrix = matrix.at[1:, 1:].set(0)
     vector = jr.normal(getkey(), (out_size,), dtype=dtype)
     lx_solve = lambda vec: lx.linear_solve(
-        lx.MatrixLinearOperator(matrix), vec, lx.QR()
+        lx.MatrixLinearOperator(matrix), vec, solver
     ).value
     jnp_solve = lambda vec: jnp.linalg.lstsq(matrix, vec)[0]  # pyright: ignore
     if jvp:
@@ -202,11 +232,9 @@ def test_qr_nonsquare_vec(full_rank, jvp, wide, dtype, getkey):
         args = ((vector,), (t_vector,))
     else:
         args = (vector,)
-    with context:
-        x = lx_solve(*args)  # pyright: ignore
-    if full_rank:
-        true_x = jnp_solve(*args)
-        assert tree_allclose(x, true_x, atol=1e-4, rtol=1e-4)
+    x = lx_solve(*args)  # pyright: ignore
+    true_x = jnp_solve(*args)
+    assert tree_allclose(x, true_x, atol=1e-4, rtol=1e-4)
 
 
 _iterative_solvers = (

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -175,7 +175,7 @@ def test_grad_vmap_symbolic_cotangent():
     "solver",
     (
         lx.CG(0.0, 0.0, max_steps=2),
-        lx.NormalCG(0.0, 0.0, max_steps=2),
+        lx.Normal(lx.CG(0.0, 0.0, max_steps=2)),
         lx.BiCGStab(0.0, 0.0, max_steps=2),
         lx.GMRES(0.0, 0.0, max_steps=2),
     ),

--- a/tests/test_well_posed.py
+++ b/tests/test_well_posed.py
@@ -53,7 +53,7 @@ def test_small_wellposed(make_operator, solver, tags, ops, getkey, dtype):
 def test_pytree_wellposed(solver, getkey, dtype):
     if not isinstance(
         solver,
-        (lx.Diagonal, lx.Triangular, lx.Tridiagonal, lx.Cholesky, lx.CG, lx.NormalCG),
+        (lx.Diagonal, lx.Triangular, lx.Tridiagonal, lx.Cholesky, lx.CG),
     ):
         if jax.config.jax_enable_x64:  # pyright: ignore
             tol = 1e-10


### PR DESCRIPTION
This fixes #157 by implementing what we discussed there, a wrapper which takes any solver and applies it to the normal equations.

I've stacked this change atop #158 as the implementation is significantly cleaner taken with the change there.

This currently includes the breaking change of removing `lx.NormalCG(...)` in favor of `lx.Normal(lx.CG(...))`, so perhaps a simple definition should be made for backward compatibility. It was not clear how I should handle that from the standpoint of the documentation, as the following suffices

```python
def NormalCG(rtol: float,
        atol: float,
        norm: Callable[[PyTree], Scalar] = max_norm,
        stabilise_every: int | None = 10,
        max_steps: int | None = None):
    return Normal(CG(rtol,atol,norm,stabilise_every,max_steps))
```

but now the name NormalCG is a function, not a class, and its not clear if it be documented along with the other solvers. Would you want to add the above as an alternative, possibly deprecated interface? And if so should it be documented, and if so how?