### PR TITLE
Fixes for preconditioned krylov solvers

### DIFF
--- a/lineax/_solver/bicgstab.py
+++ b/lineax/_solver/bicgstab.py
@@ -42,9 +42,9 @@ class BiCGStab(AbstractLinearSolver[_BiCGStabState]):
     This supports the following `options` (as passed to
     `lx.linear_solve(..., options=...)`).
 
-    - `preconditioner`: A positive definite [`lineax.AbstractLinearOperator`][]
+    - `preconditioner`: A [`lineax.AbstractLinearOperator`][]
         to be used as a preconditioner. Defaults to
-        [`lineax.IdentityLinearOperator`][].
+        [`lineax.IdentityLinearOperator`][]. This method uses right preconditioning.
     - `y0`: The initial estimate of the solution to the linear system. Defaults to all
         zeros.
     """
@@ -205,15 +205,17 @@ class BiCGStab(AbstractLinearSolver[_BiCGStabState]):
         return solution, result, stats
 
     def transpose(self, state: _BiCGStabState, options: dict[str, Any]):
-        del options
-        operator = state
         transpose_options = {}
+        if "preconditioner" in options:
+            transpose_options["preconditioner"] = options["preconditioner"].transpose()
+        operator = state
         return operator.transpose(), transpose_options
 
     def conj(self, state: _BiCGStabState, options: dict[str, Any]):
-        del options
-        operator = state
         conj_options = {}
+        if "preconditioner" in options:
+            conj_options["preconditioner"] = conj(options["preconditioner"])
+        operator = state
         return conj(operator), conj_options
 
     def allow_dependent_columns(self, operator):

--- a/lineax/_solver/misc.py
+++ b/lineax/_solver/misc.py
@@ -27,7 +27,6 @@ from .._misc import strip_weak_dtype, structure_equal
 from .._operator import (
     AbstractLinearOperator,
     IdentityLinearOperator,
-    is_positive_semidefinite,
 )
 
 
@@ -52,8 +51,6 @@ def preconditioner_and_y0(
                 "The preconditioner must have `out_structure` that matches the "
                 "operator's `in_structure`."
             )
-        if not is_positive_semidefinite(preconditioner):
-            raise ValueError("The preconditioner must be positive definite.")
     try:
         y0 = options["y0"]
     except KeyError:

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -69,3 +69,58 @@ def test_functional_pytree_adjoint_complex():
     operator = FunctionLinearOperator(fn, y_struct)
     conj_operator = lx.conj(operator)
     assert tree_allclose(lx.materialise(conj_operator), lx.materialise(operator))
+
+
+if jax.config.jax_enable_x64:  # pyright: ignore
+    tol = 1e-12
+else:
+    tol = 1e-6
+
+
+@pytest.mark.parametrize(
+    "solver",
+    [
+        # in theory only 1 iteration is needed, but stopping criteria are
+        # complicated, see gh #160
+        lx.GMRES(tol, tol, max_steps=4, restart=1),
+        lx.BiCGStab(tol, tol, max_steps=3),
+        lx.NormalCG(tol, tol, max_steps=4),
+        lx.CG(tol, tol, max_steps=3),
+    ],
+)
+def test_preconditioner_adjoint(solver):
+    """Test for fix to gh #160"""
+    # Nonsymmetric poorly conditioned matrix. Without preconditioning,
+    # this would take 20+ iterations (100s for GMRES)
+    key = jax.random.key(123)
+    key, subkey = jax.random.split(key)
+    A = jax.random.uniform(key, (10, 10))
+    A += jnp.diag(jnp.arange(A.shape[0]) ** 6).astype(A.dtype)
+    b = jax.random.uniform(subkey, (A.shape[0],))
+    if isinstance(solver, lx.CG):
+        A = A.T @ A
+        tags = (lx.positive_semidefinite_tag,)
+    else:
+        tags = ()
+
+    A = lx.MatrixLinearOperator(A, tags=tags)
+    # exact inverse, should only take ~1 iteration
+    M = lx.MatrixLinearOperator(
+        jnp.linalg.inv(A.matrix),
+        tags=tags,
+    )
+
+    def solve(b):
+        out = lx.linear_solve(
+            A, b, solver=solver, options={"preconditioner": M}, throw=True
+        )
+        return out.value
+
+    # if they don't converge then this will throw an error
+    _ = solve(b)
+    A1 = jax.jacfwd(solve)(b)
+    A2 = jax.jacrev(solve)(b)
+
+    # we also do a sanity check, dx/db should give A^{-1}
+    assert tree_allclose(A1, jnp.linalg.inv(A.matrix), atol=tol, rtol=tol)
+    assert tree_allclose(A2, jnp.linalg.inv(A.matrix), atol=tol, rtol=tol)


### PR DESCRIPTION
- Uses transpose/conjugate preconditioner for transpose/conjugate linear solve for backwards pass. Previously the preconditioner was discarded in these cases leading to convergence issues. (#160)
- Clarifies some docstrings about the type of preconditioning used, and requirements the preconditioner must satisfy. (#139)