### PR TITLE
Early validation of `jac` argument of `JacobianLinearOperator

### DIFF
--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -588,11 +588,11 @@ class JacobianLinearOperator(AbstractLinearOperator):
            `jax.jacrev`. Otherwise, if not specified it will be chosen
            by default according to input and output shape.
         """
-        assert jac in [
-            None,
-            "fwd",
-            "bwd",
-        ], f"jac argument of JacobianLinearOperator must be fwd, bwd or None, got {jac}"
+        if jac not in [None, "fwd", "bwd"]:
+            raise ValueError(
+                "`jac` argument of `JacobianLinearOperator` should be either "
+                "`'fwd'`, `'bwd'`, or `None`."
+            )
         if not _has_aux:
             fn = NoneAux(fn)
         # Flush out any closed-over values, so that we can safely pass `self`

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -588,6 +588,11 @@ class JacobianLinearOperator(AbstractLinearOperator):
            `jax.jacrev`. Otherwise, if not specified it will be chosen
            by default according to input and output shape.
         """
+        assert jac in [
+            None,
+            "fwd",
+            "bwd",
+        ], f"jac argument of JacobianLinearOperator must be fwd, bwd or None, got {jac}"
         if not _has_aux:
             fn = NoneAux(fn)
         # Flush out any closed-over values, so that we can safely pass `self`


### PR DESCRIPTION
As discussed in #166 the static `jac` kwarg of `JacobianLinearOperator` is now validated in `__init__` to fail fast. Should I remove the later validation in the methods? My gut feel is it's safer to keep them in, just in case `self.jac` is incorrectly modified.

PS I'm not sure why `ruff` relinted in the way it did, my initial draft was:
```python
        assert jac in [None, "fwd", "bwd"], (
            f"jac argument of JacobianLinearOperator must be fwd, bwd or None, got {jac}"
       )
```
but it got re-formatted.